### PR TITLE
Remove calls to strcat() to fix wasm build

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -508,7 +508,7 @@ static Result eof(State *state) {
  * the last identifier being "line(12,13)"
  */
 static Result read_while_identifier(State *state) {
-    char s[1024] = "";
+    char s[1024];
     bool finished = false;
     int32_t nesting_level = 0;
     uint32_t c = PEEK;
@@ -518,7 +518,7 @@ static Result read_while_identifier(State *state) {
     if (non_identifier_char(c) || c == '(' || c == ')') {
         return res_fail;
     }
-    strcat(s, (const char*)&c);
+    s[strlen(s)] = (char) c;
     if (strlen(s) == 0) {
         return res_empty;
     }
@@ -554,7 +554,7 @@ static Result read_while_identifier(State *state) {
                 break;
             }
         }
-        strcat(s, (const char*)&c);
+        s[strlen(s)] = (char) c;
         state->lexer->advance(state->lexer, false);
     }
 


### PR DESCRIPTION
Okay, this was pretty tricky to debug, because the wasm is fairly opaque to me.

It seemed clear that `memset` was the cause, as documented in [this comment](https://github.com/tree-sitter/tree-sitter-haskell/issues/70#issuecomment-1006703684). I'm not quite sure why `strcat` was calling `memset`...

I think that calling `strcat` with a pointer to a `int32_t` isn't a very good idea anyway. C strings are null-terminated char arrays.

Hope this helps.

---

```
$ node ./tree-sitter-parse.js
(foam (key_value keyword: (identifier) value: (number_literal)))
```